### PR TITLE
time

### DIFF
--- a/src/normalization/Normalization.h
+++ b/src/normalization/Normalization.h
@@ -13,9 +13,13 @@
 
 #ifdef WITH_CUDA
 #include "opencv2/gpu/gpu.hpp"
-#endif 
+#endif
 
+#ifdef _MSC_VER
+#include "time_win.h"
+#else
 #include <sys/time.h>
+#endif
 
 #include "../segment/PixelOperations.h"
 


### PR DESCRIPTION
Normalization.h &mdash Header include `<sys/time.h>` needs Win check:
```
#ifdef _MSC_VER
#include "time_win.h"
#else
#include <sys/time.h>
#endif
```